### PR TITLE
Remove sys.path.insert() from the example scripts

### DIFF
--- a/examples/example1.py
+++ b/examples/example1.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import numpy, math
 

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import numpy
 import numpy.random

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import math, numpy
 

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import math, numpy
 

--- a/examples/example5.py
+++ b/examples/example5.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import math, numpy
 

--- a/examples/example6.py
+++ b/examples/example6.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import numpy, math
 

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 import numpy
 

--- a/examples/example9.py
+++ b/examples/example9.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.insert(1,'..')
-
 import biggles
 from numpy import *
 


### PR DESCRIPTION
This line was meant to allow the example scripts to be run in the source
directory. However, this is not possible anymore with recent versions of
distutils; biggles needs to be installed first. Closes #47.
