### PR TITLE
bug fix for segfault in X11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,10 +9,11 @@ Features
 Bug Fixes
 ----------
 
-* add try/finally block around page_compose() to guarantee
-  the device is closed. This prevents a seg fault that
-  could occur when the X11 device was open and an
-  error occured, and the device was not then closed. 
+* make ScreenRender close itself after leaving the context
+  manager (or being cleaned up). This prevents a seg fault that could occur
+  when the X11 device was open and an error occured, and the device was not
+  then closed.  This was basically a mistake on my part thinking
+  that close would close the window, so I had not deleted it.
 
 1.7.2 (14 Mar 2017)
 ===================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,14 @@ Features
 
 * plots now show inline in jupyter notebooks
 
+Bug Fixes
+----------
+
+* add try/finally block around page_compose() to guarantee
+  the device is closed. This prevents a seg fault that
+  could occur when the X11 device was open and an
+  error occured, and the device was not then closed. 
+
 1.7.2 (14 Mar 2017)
 ===================
 

--- a/biggles/biggles.py
+++ b/biggles/biggles.py
@@ -2509,15 +2509,13 @@ class _PlotContainer(_ConfAttributes):
 
     def page_compose(self, device):
         device.open()
-        try:
-            bb = BoundingBox(device.lowerleft, device.upperright)
-            device.bbox = bb.copy()
-            for key, val in config.options('default').items():
-                device.set(key, val)
-            bb.expand(-self.page_margin)
-            self.compose(device, bb)
-        finally:
-            device.close()
+        bb = BoundingBox(device.lowerleft, device.upperright)
+        device.bbox = bb.copy()
+        for key, val in config.options('default').items():
+            device.set(key, val)
+        bb.expand(-self.page_margin)
+        self.compose(device, bb)
+        device.close()
 
     def show(self, width=None, height=None, dpi=55):
         """
@@ -2564,6 +2562,7 @@ class _PlotContainer(_ConfAttributes):
             config.bool('screen', 'persistent')
 
         with ScreenRenderer(persistent, width, height) as device:
+            # note after leaving context, device is closed
             self.page_compose(device)
 
     def show_win(self, width, height):

--- a/biggles/biggles.py
+++ b/biggles/biggles.py
@@ -2561,6 +2561,9 @@ class _PlotContainer(_ConfAttributes):
         persistent = config.interactive() and \
             config.bool('screen', 'persistent')
 
+        if persistent:
+            raise NotImplementedError("persistent window does not work")
+
         with ScreenRenderer(persistent, width, height) as device:
             # note after leaving context, device is closed
             self.page_compose(device)

--- a/biggles/biggles.py
+++ b/biggles/biggles.py
@@ -2509,13 +2509,15 @@ class _PlotContainer(_ConfAttributes):
 
     def page_compose(self, device):
         device.open()
-        bb = BoundingBox(device.lowerleft, device.upperright)
-        device.bbox = bb.copy()
-        for key, val in config.options('default').items():
-            device.set(key, val)
-        bb.expand(-self.page_margin)
-        self.compose(device, bb)
-        device.close()
+        try:
+            bb = BoundingBox(device.lowerleft, device.upperright)
+            device.bbox = bb.copy()
+            for key, val in config.options('default').items():
+                device.set(key, val)
+            bb.expand(-self.page_margin)
+            self.compose(device, bb)
+        finally:
+            device.close()
 
     def show(self, width=None, height=None, dpi=55):
         """

--- a/biggles/libplot/renderer.py
+++ b/biggles/libplot/renderer.py
@@ -436,7 +436,7 @@ class InteractiveScreenRenderer(LibplotRenderer):
 
     def close(self):
         self.flush()
-        self.close()
+        super(InteractiveScreenRenderer,self).close()
 
     def __exit__(self, exception_type, exception_value, traceback):
         self.close()

--- a/biggles/libplot/renderer.py
+++ b/biggles/libplot/renderer.py
@@ -444,9 +444,9 @@ class InteractiveScreenRenderer(LibplotRenderer):
 _saved_screen_renderer = None
 
 
-def ScreenRenderer(persistent=0, width=512, height=512):
+def ScreenRenderer(persistent=False, width=512, height=512):
 
-    if persistent == 1:
+    if persistent:
         global _saved_screen_renderer
         if _saved_screen_renderer is None:
             _saved_screen_renderer \

--- a/biggles/libplot/renderer.py
+++ b/biggles/libplot/renderer.py
@@ -164,10 +164,6 @@ class LibplotRenderer(Plotter):
         #raw.clear( self.pl )
         self.clear()
 
-    # def close( self ):
-    #    if self.pl is not None:
-    #        #raw.end_page( self.pl )
-    #        self.pl.end_page()
     def close(self):
         self.end_page()
 
@@ -177,23 +173,6 @@ class LibplotRenderer(Plotter):
     def __exit__(self, exception_type, exception_value, traceback):
         pass
         # self.flush()
-
-    '''
-    def delete( self ):
-        """ 
-        if not hasattr(self, 'pl'):
-            return
-        if self.pl is not None:
-            #raw.delete( self.pl )
-            del self.pl
-            self.pl = None
-        """
-        pass
-    '''
-    """
-    def __del__( self ):
-        self.delete()
-    """
 
     # state commands
 
@@ -437,10 +416,8 @@ class NonInteractiveScreenRenderer(LibplotRenderer):
                                                            parameters)
 
     def __exit__(self, exception_type, exception_value, traceback):
-        """
-        we don't close screen
-        """
         self.flush()
+        self.close()
 
 
 class InteractiveScreenRenderer(LibplotRenderer):
@@ -458,20 +435,11 @@ class InteractiveScreenRenderer(LibplotRenderer):
                                                         parameters)
 
     def close(self):
-        #raw.flush( self.pl )
         self.flush()
+        self.close()
 
     def __exit__(self, exception_type, exception_value, traceback):
-        """
-        we don't close screen
-        """
-        self.flush()
-
-    '''
-    def delete( self ):
-        #raw.flush( self.pl )
-        self.flush()
-    '''
+        self.close()
 
 _saved_screen_renderer = None
 


### PR DESCRIPTION
This addresses issue #110 

put a try finally block in page_compose() to make sure the device closes
even when there was an error. apparently if not closed a seg fault
occurs when a new x11 connection is made.

also update changelog